### PR TITLE
Prevent distance flicker

### DIFF
--- a/app/assets/javascripts/stores/triplocations-store.js
+++ b/app/assets/javascripts/stores/triplocations-store.js
@@ -167,13 +167,29 @@
         type: 'json'
       }).then( function(data) {
         log('triplocations fetch returned', data);
-        this.triplocations = data;
-        this.emit( 'change' );
+        this.setTriplocations(data);
       }.bind( this ) ).fail( function() {
         log( 'triplocation fetch failed' );
         var message = 'Fetching triplocations failed because the request returned an error. Try reloading the page.';
         emitter.emit( 'error', message );
       } );
+    },
+
+    setTriplocations: function( triplocations ) {
+      if ( ! this.sameTrip(triplocations) ) {
+        log('trip has changed, sending change event');
+        this.triplocations = triplocations;
+        this.emit( 'change' );
+      } else {
+        log('trip has not changed, silently updating');
+        this.triplocations = triplocations;
+      }
+    },
+
+    sameTrip: function( data ) {
+      var newData = data.map( function(item) { return item.location.id; } );
+      var oldData = this.triplocations.map( function(item) { return item.location.id; } );
+      return (newData.length === oldData.length && newData.every( function(val, index) { return val === oldData[index]; } ));
     }
   } );
 } )();

--- a/app/assets/javascripts/tripmap.js.jsx
+++ b/app/assets/javascripts/tripmap.js.jsx
@@ -83,6 +83,12 @@ var TripMap = ( function() { //jshint ignore:line
     },
 
     componentDidMount : function() {
+      if ( ! window.google ) {
+        log( 'google is not defined' );
+        var message = 'The map failed to load because Google is not reachable. Try reloading the page.';
+        emitter.emit( 'error', message );
+        return;
+      }
       this.directionsService = new google.maps.DirectionsService();
       this.directionsRenderer = new google.maps.DirectionsRenderer();
 
@@ -106,6 +112,12 @@ var TripMap = ( function() { //jshint ignore:line
     },
 
     componentWillReceiveProps : function() {
+      if ( ! window.google ) {
+        log( 'google is not defined' );
+        var message = 'The map failed to load because Google is not reachable. Try reloading the page.';
+        emitter.emit( 'error', message );
+        return;
+      }
       this.calculateRoute();
     }
 


### PR DESCRIPTION
The distance loading indicator flickers when a Triplocation is added or removed because after every modification to the Trip, a call is made to `TriplocationsStore.fetch()` in order to make sure the data is synchronized correctly, and this second call then calls `Trip.getTrip()`. That is, if the trip was changed on the server sometime since the last sync, this will make sure it's all accurate. However, when nothing has changed, it causes an unnecessary call to `Trip.showPending()`, showing up as a flicker.

This change prevents a `change` event from being triggered on `TriplocationStore` when an update doesn't change the trip (triplocation IDs may change, but those are not relevant to the user), preventing the call to `Trip.getTrip()` and the flicker.
